### PR TITLE
fix: handle null values in extra_usage API response

### DIFF
--- a/Sources/ClaudeCodeUsage/Models/UsageData.swift
+++ b/Sources/ClaudeCodeUsage/Models/UsageData.swift
@@ -88,9 +88,9 @@ struct UsageAPIResponse: Decodable {
     }
 
     struct ExtraUsageResponse: Decodable {
-        let utilization: Double
-        let monthlyLimit: Int
-        let usedCredits: Int
+        let utilization: Double?
+        let monthlyLimit: Int?
+        let usedCredits: Int?
         let isEnabled: Bool
 
         enum CodingKeys: String, CodingKey {
@@ -131,11 +131,17 @@ struct UsageAPIResponse: Decodable {
                     resetsAt: response.resetsAt
                 )
             },
-            extraUsage: extraUsage.map { response in
-                UsageData.ExtraUsage(
-                    utilization: response.utilization,
-                    usedCredits: response.usedCredits,
-                    monthlyLimit: response.monthlyLimit,
+            extraUsage: extraUsage.flatMap { response in
+                // Only create ExtraUsage if we have the required values
+                guard let utilization = response.utilization,
+                      let usedCredits = response.usedCredits,
+                      let monthlyLimit = response.monthlyLimit else {
+                    return nil
+                }
+                return UsageData.ExtraUsage(
+                    utilization: utilization,
+                    usedCredits: usedCredits,
+                    monthlyLimit: monthlyLimit,
                     isEnabled: response.isEnabled
                 )
             },


### PR DESCRIPTION
## Summary
- Fix JSON decoding error when `extra_usage` fields are null
- Make `utilization`, `monthlyLimit`, and `usedCredits` optional in `ExtraUsageResponse`
- Handle missing values by returning nil for the entire `extraUsage` object

## Problem
The API returns null for `extra_usage.utilization`, `extra_usage.used_credits`, and `extra_usage.monthly_limit` when extra usage isn't enabled:

```json
"extra_usage": {
  "utilization": null,
  "monthly_limit": null,
  "used_credits": null,
  "is_enabled": false
}
```

This was causing me to not be able to authenticate. I guess I have extra usage disabled on my Claude account. 